### PR TITLE
AOS-3749 set order in bean method instead of annotation

### DIFF
--- a/src/main/java/no/skatteetaten/aurora/config/ApplicationConfig.java
+++ b/src/main/java/no/skatteetaten/aurora/config/ApplicationConfig.java
@@ -15,7 +15,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertiesPropertySource;
 
@@ -43,11 +42,11 @@ public class ApplicationConfig {
      */
     @Bean
     @ConditionalOnProperty(prefix = "aurora.starter.headerfilter", name = "enabled", matchIfMissing = true)
-    @Order(Ordered.HIGHEST_PRECEDENCE)
     public FilterRegistrationBean auroraHeaderFilter() {
         FilterRegistrationBean registration = new FilterRegistrationBean();
         registration.addUrlPatterns("/*");
         registration.setFilter(new AuroraHeaderFilter());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return registration;
     }
 


### PR DESCRIPTION
@Order på FilterRegistrationBeans blir ikke respektert i aurora-spring-boot2-starter

https://github.com/spring-projects/spring-boot/issues/18210

> I'm afraid that you can't use @Order on the bean method. You either need to add @Order to TestFilter or use a FilterRegistrationBean and explicitly set the order.